### PR TITLE
ENH rerender for proper version

### DIFF
--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.16.27032.1
+- 19.16.27038
 cross_compiler_target_platform:
 - win-64
 pin_run_as_build:

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -14,7 +14,7 @@ pin_run_as_build:
   vc:
     max_pin: x
 runtime_version:
-- 14.16.27032
+- 14.16.27012
 update_version:
 - '9'
 vc:

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -14,8 +14,8 @@ pin_run_as_build:
   vc:
     max_pin: x
 runtime_version:
-- 14.16.27012
+- 14.16.27032
 update_version:
 - '9'
 vc:
-- '14'
+- '14.1'

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license:
 
 Feedstock license: BSD 3-Clause
 
-Summary: MSVC runtimes associated with cl.exe version 19.16.27032.1 (VS 2017 update 9)
+Summary: MSVC runtimes associated with cl.exe version 19.16.27038 (VS 2017 update 9)
 
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,7 +7,7 @@ update_version:
   - 9
 # this is the version number reported by cl.exe
 cl_version:
-  - 19.16.27032.1
+  - 19.16.27038
 # this version follows the version number reported for the vcruntim140.dll file.
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Redist\MSVC\14.15.26706\x64\Microsoft.VC141.CRT
 #     Note the 14.15.26706 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -14,3 +14,7 @@ cl_version:
 runtime_version:
   - 14.16.27032
 # we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.
+
+# make sure to set this properly
+vc:
+  - 14.1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,7 +12,7 @@ cl_version:
 #     This will be in a folder like C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Redist\MSVC\14.15.26706\x64\Microsoft.VC141.CRT
 #     Note the 14.15.26706 in there - that's what we want, but in case their folder scheme changes, it's better to base it on the version of the file itself.
 runtime_version:
-  - 14.16.27032
+  - 14.16.27012
 # we could zip all these together, and we should do that if there's ever more than one version supported at once.  I don't think that's currently possible, though.
 
 # make sure to set this properly

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
   version: {{ fullver }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not win]
 
 outputs:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
It appears that the version reported by cl.exe is different from what is in the recipe. This PR fixes that.