### PR TITLE
Fix activate bat

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -27,9 +27,9 @@ set "NEWER_VS_WITH_OLDER_VC=0"
 for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[@{ver}.0^,@{ver_plus_one}.0^) -property productId`) do (
     if not "%%i" == "Microsoft.VisualStudio.Product.Professional" (
         for /f "usebackq tokens=*" %%j in (`vswhere.exe -nologo -products %%i -version ^[@{ver}.0^,@{ver_plus_one}.0^) -property installationPath`) do (
-	    :: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it:
-	    set "VSINSTALLDIR=%%j\"
-	)
+            :: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it:
+	        set "VSINSTALLDIR=%%j\"
+	    )
     )
 )
 

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -20,29 +20,35 @@ set "CXX=cl.exe"
 set "CC=cl.exe"
 
 set "VSINSTALLDIR="
+
 :: Try to find actual vs2017 installations
-for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version ^[@{ver}.0^,@{ver_plus_one}.0^) -property installationPath`) do (
-  :: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
-  set "VSINSTALLDIR=%%i\"
-)
-if not exist "%VSINSTALLDIR%" (
-    :: VS2019 install but with vs2017 compiler stuff installed
-	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v@{vcver_nodots}.x86.x64 -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products Microsoft.VisualStudio.Product.BuildTools -version ^[@{ver}.0^,@{ver_plus_one}.0^) -property installationPath`) do (
 	:: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
 	set "VSINSTALLDIR=%%i\"
+)
+
+if not exist "%VSINSTALLDIR%" (
+	:: VS2019 install but with vs2017 compiler stuff installed
+	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v@{vcver_nodots}.x86.x64 -property installationPath`) do (
+		:: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
+		set "VSINSTALLDIR=%%i\"
 	)
 )
+
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Professional\"
+	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Professional\"
 )
+
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Community\"
+	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Community\"
 )
+
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\BuildTools\"
+	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\BuildTools\"
 )
+
 if not exist "%VSINSTALLDIR%" (
-set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Enterprise\"
+	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Enterprise\"
 )
 
 IF NOT "%CONDA_BUILD%" == "" (
@@ -51,8 +57,8 @@ IF NOT "%CONDA_BUILD%" == "" (
   set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
 )
 
-
 call :GetWin10SdkDir
+
 :: dir /ON here is sorting the list of folders, such that we use the latest one that we have
 for /F %%i in ('dir /ON /B "%WindowsSdkDir%\include\10.*"') DO (
   SET WindowsSDKVer=%%~i

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -23,45 +23,45 @@ set "VSINSTALLDIR="
 
 :: Try to find actual vs2017 installations
 for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products Microsoft.VisualStudio.Product.BuildTools -version ^[@{ver}.0^,@{ver_plus_one}.0^) -property installationPath`) do (
-	:: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
-	set "VSINSTALLDIR=%%i\"
+    :: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
+    set "VSINSTALLDIR=%%i\"
 )
 
 if not exist "%VSINSTALLDIR%" (
-	:: VS2019 install but with vs2017 compiler stuff installed
-	for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v@{vcver_nodots}.x86.x64 -property installationPath`) do (
-		:: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
-		set "VSINSTALLDIR=%%i\"
-	)
+    :: VS2019 install but with vs2017 compiler stuff installed
+    for /f "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -requires Microsoft.VisualStudio.Component.VC.v@{vcver_nodots}.x86.x64 -property installationPath`) do (
+        :: There is no trailing back-slash from the vswhere, and may make vcvars64.bat fail, so force add it
+        set "VSINSTALLDIR=%%i\"
+    )
 )
 
 if not exist "%VSINSTALLDIR%" (
-	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Professional\"
+    set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Professional\"
 )
 
 if not exist "%VSINSTALLDIR%" (
-	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Community\"
+    set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Community\"
 )
 
 if not exist "%VSINSTALLDIR%" (
-	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\BuildTools\"
+    set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\BuildTools\"
 )
 
 if not exist "%VSINSTALLDIR%" (
-	set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Enterprise\"
+    set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Enterprise\"
 )
 
 IF NOT "%CONDA_BUILD%" == "" (
-  set "INCLUDE=%LIBRARY_INC%;%INCLUDE%"
-  set "LIB=%LIBRARY_LIB%;%LIB%"
-  set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
+    set "INCLUDE=%LIBRARY_INC%;%INCLUDE%"
+    set "LIB=%LIBRARY_LIB%;%LIB%"
+    set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
 )
 
 call :GetWin10SdkDir
 
 :: dir /ON here is sorting the list of folders, such that we use the latest one that we have
 for /F %%i in ('dir /ON /B "%WindowsSdkDir%\include\10.*"') DO (
-  SET WindowsSDKVer=%%~i
+    SET WindowsSDKVer=%%~i
 )
 if errorlevel 1 (
     echo "Didn't find any windows 10 SDK. I'm not sure if things will work, but let's try..."
@@ -84,7 +84,7 @@ IF @{year} GEQ 2019 (
     IF "@{target}" == "win-64" (
         set "CMAKE_GEN=Visual Studio @{ver} @{year} Win64"
         set "BITS=64"
-	) else (
+    ) else (
         set "CMAKE_GEN=Visual Studio @{ver} @{year}"
         set "BITS=32"
     )
@@ -97,7 +97,7 @@ popd
 IF "%CMAKE_GENERATOR%" == "" SET "CMAKE_GENERATOR=%CMAKE_GEN%"
 :: see https://cmake.org/cmake/help/latest/envvar/CMAKE_GENERATOR_PLATFORM.html
 IF @{year} GEQ 2019 (
-	IF "%CMAKE_GENERATOR_PLATFORM%" == "" SET "CMAKE_GENERATOR_PLATFORM=%CMAKE_PLAT%"
+    IF "%CMAKE_GENERATOR_PLATFORM%" == "" SET "CMAKE_GENERATOR_PLATFORM=%CMAKE_PLAT%"
 )
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     sha256: {{ sha256 | lower }}  # [win32]
 
 build:
-  number: 5
+  number: 6
   skip: True  # [not win]
 
 outputs:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

When both VS2017 Professional and the BuildTools are installed, `vswhere` returns two lines of output:

    >vswhere.exe -nologo -products * -version ^[15.0^,16.0^) -property installationPath
    C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional
    C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools

These are in random order, and only the last one is used to set `_VSINSTALLDIR`. If that happens to be the wrong one (Professional instead of BuildTools) then the SDK will not be detected, nothing will be added to the `PATH`, and compilations will fail with:

> 'cl.exe' is not recognized as an internal or external command, operable program or batch file.

This change ensures that we always find the BuildTools, even if Professional is also installed.