### PR TITLE
add fallback to activate without vcvars_ver if not CONDA_BUILD

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -126,6 +126,14 @@ IF "%USE_NEW_CMAKE_GEN_SYNTAX%" == "1" (
 
 pushd %VSINSTALLDIR%
 CALL "VC\Auxiliary\Build\vcvars%BITS%.bat" -vcvars_ver=@{vcvars_ver} %WindowsSDKVer%
+:: if this didn't work and CONDA_BUILD is not set, we're outside
+:: conda-forge CI so retry without vcvars_ver, which is going to
+:: fail on local installs that don't match our exact versions
+if %ERRORLEVEL% neq 0 (
+  if "%CONDA_BUILD%" == "" (
+    CALL "VC\Auxiliary\Build\vcvars%BITS%.bat"
+  )
+)
 popd
 
 :GetWin10SdkDir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     sha256: {{ sha256 | lower }}  # [win32]
 
 build:
-  number: 10
+  number: 11
   skip: True  # [not win]
 
 outputs:


### PR DESCRIPTION
Implemented the [suggestion](https://github.com/conda-forge/vc-feedstock/pull/54#issuecomment-1513871579) from #54.

