### PR TITLE
Add VS2022 17.6

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -43,6 +43,11 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: win_arm64_cl_version19.36.32532cros_h0267430ae8
+      win_arm64_cl_version19.36.32532cros_hd5bd5a4e25:
+        CONFIG: win_arm64_cl_version19.36.32532cros_hd5bd5a4e25
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: win_arm64_cl_version19.36.32532cros_hd5bd5a4e25
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -38,6 +38,11 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: win_arm64_cl_version19.35.32217cros_hee5033cc0b
+      win_arm64_cl_version19.36.32532cros_h0267430ae8:
+        CONFIG: win_arm64_cl_version19.36.32532cros_h0267430ae8
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: win_arm64_cl_version19.36.32532cros_h0267430ae8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -36,6 +36,10 @@ jobs:
         CONFIG: win_64_cl_version19.36.32532cross_t_h23db042d00
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: win_64_cl_version19.36.32532cross_t_h23db042d00
+      win_64_cl_version19.36.32532cross_t_hc40340d1e0:
+        CONFIG: win_64_cl_version19.36.32532cross_t_hc40340d1e0
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_cl_version19.36.32532cross_t_hc40340d1e0
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -32,6 +32,10 @@ jobs:
         CONFIG: win_64_cl_version19.35.32217cross_t_h76368dcf58
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: win_64_cl_version19.35.32217cross_t_h76368dcf58
+      win_64_cl_version19.36.32532cross_t_h23db042d00:
+        CONFIG: win_64_cl_version19.36.32532cross_t_h23db042d00
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_cl_version19.36.32532cross_t_h23db042d00
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/win_64_cl_version19.36.32532cross_t_h23db042d00.yaml
+++ b/.ci_support/win_64_cl_version19.36.32532cross_t_h23db042d00.yaml
@@ -1,0 +1,36 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cl_version:
+- 19.36.32532
+cross_target_platform:
+- win-64
+runtime_version:
+- 14.36.32532
+sha256:
+- 917C37D816488545B70AFFD77D6E486E4DD27E2ECE63F6BBAAF486B178B2B888
+target_platform:
+- win-64
+update_version:
+- '6'
+uuid:
+- eaab1f82-787d-4fd7-8c73-f782341a0c63
+vc:
+- '14'
+vcver:
+- '14.3'
+vsver:
+- '17'
+vsyear:
+- '2022'
+zip_keys:
+- - vcver
+  - vsyear
+  - vsver
+  - runtime_version
+  - update_version
+  - cl_version
+  - uuid
+  - sha256
+  - cross_target_platform

--- a/.ci_support/win_64_cl_version19.36.32532cross_t_hc40340d1e0.yaml
+++ b/.ci_support/win_64_cl_version19.36.32532cross_t_hc40340d1e0.yaml
@@ -1,0 +1,36 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cl_version:
+- 19.36.32532
+cross_target_platform:
+- win-arm64
+runtime_version:
+- 14.36.32532
+sha256:
+- 37342E0ABDAEAE0297F64A889F842AC9453139639FB0178C0754A7D2F330043A
+target_platform:
+- win-64
+update_version:
+- '6'
+uuid:
+- eaab1f82-787d-4fd7-8c73-f782341a0c63
+vc:
+- '14'
+vcver:
+- '14.3'
+vsver:
+- '17'
+vsyear:
+- '2022'
+zip_keys:
+- - vcver
+  - vsyear
+  - vsver
+  - runtime_version
+  - update_version
+  - cl_version
+  - uuid
+  - sha256
+  - cross_target_platform

--- a/.ci_support/win_arm64_cl_version19.36.32532cros_h0267430ae8.yaml
+++ b/.ci_support/win_arm64_cl_version19.36.32532cros_h0267430ae8.yaml
@@ -1,0 +1,38 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cl_version:
+- 19.36.32532
+cross_target_platform:
+- win-64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+runtime_version:
+- 14.36.32532
+sha256:
+- 917C37D816488545B70AFFD77D6E486E4DD27E2ECE63F6BBAAF486B178B2B888
+target_platform:
+- win-arm64
+update_version:
+- '6'
+uuid:
+- eaab1f82-787d-4fd7-8c73-f782341a0c63
+vc:
+- '14'
+vcver:
+- '14.3'
+vsver:
+- '17'
+vsyear:
+- '2022'
+zip_keys:
+- - vcver
+  - vsyear
+  - vsver
+  - runtime_version
+  - update_version
+  - cl_version
+  - uuid
+  - sha256
+  - cross_target_platform

--- a/.ci_support/win_arm64_cl_version19.36.32532cros_hd5bd5a4e25.yaml
+++ b/.ci_support/win_arm64_cl_version19.36.32532cros_hd5bd5a4e25.yaml
@@ -1,0 +1,38 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cl_version:
+- 19.36.32532
+cross_target_platform:
+- win-arm64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+runtime_version:
+- 14.36.32532
+sha256:
+- 37342E0ABDAEAE0297F64A889F842AC9453139639FB0178C0754A7D2F330043A
+target_platform:
+- win-arm64
+update_version:
+- '6'
+uuid:
+- eaab1f82-787d-4fd7-8c73-f782341a0c63
+vc:
+- '14'
+vcver:
+- '14.3'
+vsver:
+- '17'
+vsyear:
+- '2022'
+zip_keys:
+- - vcver
+  - vsyear
+  - vsver
+  - runtime_version
+  - update_version
+  - cl_version
+  - uuid
+  - sha256
+  - cross_target_platform

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>win_64_cl_version19.36.32532cross_t_h23db042d00</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.16.27033cros_hff19a857c3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_arm64_cl_version19.16.27033cros_h10441f7228</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
@@ -191,6 +198,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.35.32217cros_hee5033cc0b" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_arm64_cl_version19.36.32532cros_h0267430ae8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.35.32217cros_h50145d0572" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -206,7 +220,7 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vc-green.svg)](https://anaconda.org/conda-forge/vc) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vc.svg)](https://anaconda.org/conda-forge/vc) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vc.svg)](https://anaconda.org/conda-forge/vc) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vc.svg)](https://anaconda.org/conda-forge/vc) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vc14_runtime-green.svg)](https://anaconda.org/conda-forge/vc14_runtime) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vc14_runtime.svg)](https://anaconda.org/conda-forge/vc14_runtime) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vc14_runtime.svg)](https://anaconda.org/conda-forge/vc14_runtime) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vc14_runtime.svg)](https://anaconda.org/conda-forge/vc14_runtime) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-vs2015_version-green.svg)](https://anaconda.org/conda-forge/vs2015_version) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vs2015_version.svg)](https://anaconda.org/conda-forge/vs2015_version) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vs2015_version.svg)](https://anaconda.org/conda-forge/vs2015_version) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vs2015_version.svg)](https://anaconda.org/conda-forge/vs2015_version) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-vs2015_runtime-green.svg)](https://anaconda.org/conda-forge/vs2015_runtime) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vs2015_runtime.svg)](https://anaconda.org/conda-forge/vs2015_runtime) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vs2015_runtime.svg)](https://anaconda.org/conda-forge/vs2015_runtime) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vs2015_runtime.svg)](https://anaconda.org/conda-forge/vs2015_runtime) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vs2017_win--64-green.svg)](https://anaconda.org/conda-forge/vs2017_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vs2017_win-64.svg)](https://anaconda.org/conda-forge/vs2017_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vs2017_win-64.svg)](https://anaconda.org/conda-forge/vs2017_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vs2017_win-64.svg)](https://anaconda.org/conda-forge/vs2017_win-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vs2019_win--64-green.svg)](https://anaconda.org/conda-forge/vs2019_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vs2019_win-64.svg)](https://anaconda.org/conda-forge/vs2019_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vs2019_win-64.svg)](https://anaconda.org/conda-forge/vs2019_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vs2019_win-64.svg)](https://anaconda.org/conda-forge/vs2019_win-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-vs2022_win--64-green.svg)](https://anaconda.org/conda-forge/vs2022_win-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/vs2022_win-64.svg)](https://anaconda.org/conda-forge/vs2022_win-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/vs2022_win-64.svg)](https://anaconda.org/conda-forge/vs2022_win-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/vs2022_win-64.svg)](https://anaconda.org/conda-forge/vs2022_win-64) |
@@ -224,16 +238,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `vc, vc14_runtime, vs2015_version, vs2017_win-64, vs2019_win-64, vs2022_win-64, vs2022_win-arm64, vs_win-64, vs_win-arm64` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `vc, vc14_runtime, vs2015_runtime, vs2017_win-64, vs2019_win-64, vs2022_win-64, vs2022_win-arm64, vs_win-64, vs_win-arm64` can be installed with `conda`:
 
 ```
-conda install vc vc14_runtime vs2015_version vs2017_win-64 vs2019_win-64 vs2022_win-64 vs2022_win-arm64 vs_win-64 vs_win-arm64
+conda install vc vc14_runtime vs2015_runtime vs2017_win-64 vs2019_win-64 vs2022_win-64 vs2022_win-arm64 vs_win-64 vs_win-arm64
 ```
 
 or with `mamba`:
 
 ```
-mamba install vc vc14_runtime vs2015_version vs2017_win-64 vs2019_win-64 vs2022_win-64 vs2022_win-arm64 vs_win-64 vs_win-arm64
+mamba install vc vc14_runtime vs2015_runtime vs2017_win-64 vs2019_win-64 vs2022_win-64 vs2022_win-arm64 vs_win-64 vs_win-arm64
 ```
 
 It is possible to list all of the versions of `vc` available on your platform with `conda`:

--- a/README.md
+++ b/README.md
@@ -153,7 +153,14 @@ Current build status
               <td>win_64_cl_version19.36.32532cross_t_h23db042d00</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.16.27033cros_hff19a857c3" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.36.32532cross_t_h23db042d00" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cl_version19.36.32532cross_t_hc40340d1e0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.36.32532cross_t_hc40340d1e0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -202,7 +209,14 @@ Current build status
               <td>win_arm64_cl_version19.36.32532cros_h0267430ae8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.35.32217cros_h50145d0572" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.36.32532cros_h0267430ae8" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_arm64_cl_version19.36.32532cros_hd5bd5a4e25</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.36.32532cros_hd5bd5a4e25" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,10 +3,12 @@ vcver:
  - 14.3
  - 14.3
  - 14.3
+ - 14.3
  - 14.2
  - 14.2
  - 14.1
 vsyear:
+ - 2022
  - 2022
  - 2022
  - 2022
@@ -19,6 +21,7 @@ vsver:
  - 17
  - 17
  - 17
+ - 17
  - 16
  - 16
  - 15
@@ -26,6 +29,7 @@ runtime_version:
  # the minor version here can show up in the toolset directory path
  # used by vcvars.bat (see #36), hence we need multiple builds even
  # though they're from the same vsver-line.
+ - 14.36.32532
  - 14.36.32532
  - 14.34.31938
  - 14.34.31931
@@ -38,6 +42,7 @@ runtime_version:
 # referenceable number.
 update_version:
  - 6
+ - 6
  - 5
  - 4
  - 2
@@ -46,6 +51,7 @@ update_version:
  - 9
 # This is the version number reported by cl.exe
 cl_version:
+ - 19.36.32532
  - 19.36.32532
  - 19.35.32217
  - 19.34.31933
@@ -58,6 +64,7 @@ cl_version:
 # curl -ILSs https://aka.ms/vs/17/release/vc_redist.arm64.exe | grep "Location:"
 uuid:
  - eaab1f82-787d-4fd7-8c73-f782341a0c63
+ - eaab1f82-787d-4fd7-8c73-f782341a0c63
  - b2519016-4a13-4120-936c-cae003d567c4
  - bcb0cef1-f8cb-4311-8a5c-650a5b694eab
  - 7331f052-6c2d-4890-8041-8058fee5fb0f
@@ -65,6 +72,7 @@ uuid:
  - 89a3b9df-4a09-492e-8474-8f92c115c51d
  - 4100b84d-1b4d-487d-9f89-1354a7138c8f
 sha256:
+ - 37342E0ABDAEAE0297F64A889F842AC9453139639FB0178C0754A7D2F330043A
  - 917C37D816488545B70AFFD77D6E486E4DD27E2ECE63F6BBAAF486B178B2B888
  - EC530B52C87AF9DBECBCCE83E5945FD0CAA57969A858D7497E4D5CBBD6F53F60
  - 2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9
@@ -73,6 +81,7 @@ sha256:
  - B1A32C71A6B7D5978904FB223763263EA5A7EB23B2C44A0D60E90D234AD99178
  - 5B0CBB977F2F5253B1EBE5C9D30EDBDA35DBD68FB70DE7AF5FAAC6423DB575B5
 cross_target_platform:
+ - win-arm64
  - win-64
  - win-arm64
  - win-64

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,10 +2,12 @@ vcver:
  - 14.3
  - 14.3
  - 14.3
+ - 14.3
  - 14.2
  - 14.2
  - 14.1
 vsyear:
+ - 2022
  - 2022
  - 2022
  - 2022
@@ -16,6 +18,7 @@ vsver:
  - 17
  - 17
  - 17
+ - 17
  - 16
  - 16
  - 15
@@ -23,6 +26,7 @@ runtime_version:
  # the minor version here can show up in the toolset directory path
  # used by vcvars.bat (see #36), hence we need multiple builds even
  # though they're from the same vsver-line.
+ - 14.36.32532
  - 14.34.31938
  - 14.34.31931
  - 14.32.31332
@@ -33,6 +37,7 @@ runtime_version:
 # reported in the VS help->about UI.  It is perhaps a more readily
 # referenceable number.
 update_version:
+ - 6
  - 5
  - 4
  - 2
@@ -41,6 +46,7 @@ update_version:
  - 9
 # This is the version number reported by cl.exe
 cl_version:
+ - 19.36.32532
  - 19.35.32217
  - 19.34.31933
  - 19.33.31629
@@ -51,6 +57,7 @@ cl_version:
 # curl -ILSs https://aka.ms/vs/17/release/vc_redist.x64.exe | grep "Location:"
 # curl -ILSs https://aka.ms/vs/17/release/vc_redist.arm64.exe | grep "Location:"
 uuid:
+ - eaab1f82-787d-4fd7-8c73-f782341a0c63
  - b2519016-4a13-4120-936c-cae003d567c4
  - bcb0cef1-f8cb-4311-8a5c-650a5b694eab
  - 7331f052-6c2d-4890-8041-8058fee5fb0f
@@ -58,6 +65,7 @@ uuid:
  - 89a3b9df-4a09-492e-8474-8f92c115c51d
  - 4100b84d-1b4d-487d-9f89-1354a7138c8f
 sha256:
+ - 917C37D816488545B70AFFD77D6E486E4DD27E2ECE63F6BBAAF486B178B2B888
  - EC530B52C87AF9DBECBCCE83E5945FD0CAA57969A858D7497E4D5CBBD6F53F60
  - 2257B3FBE3C7559DE8B31170155A433FAF5B83829E67C589D5674FF086B868B9
  - CE6593A1520591E7DEA2B93FD03116E3FC3B3821A0525322B0A430FAA6B3C0B4
@@ -65,6 +73,7 @@ sha256:
  - B1A32C71A6B7D5978904FB223763263EA5A7EB23B2C44A0D60E90D234AD99178
  - 5B0CBB977F2F5253B1EBE5C9D30EDBDA35DBD68FB70DE7AF5FAAC6423DB575B5
 cross_target_platform:
+ - win-64
  - win-arm64
  - win-64
  - win-64

--- a/recipe/vc_repack.py
+++ b/recipe/vc_repack.py
@@ -247,10 +247,17 @@ def decode_manifest(directory):
 def fix_filename_and_copy(source, dest):
     cwd = os.getcwd()
     os.chdir(source)
-    for fname in glob.glob("*.dll"):
+    # as of VS 17.6, the artefact contains intermediate DLL extensions,
+    # which get renamed correctly upon installation; do it manually
+    candidates = glob.glob("*.dll") + glob.glob("*.dll_amd64")
+    for fname in candidates:
         print(f"Found DLL: {fname}")
         if fname.startswith("api_"):
             new_fname = fname.replace("_", "-")
+            os.rename(fname, new_fname)
+        elif fname.endswith(".dll_amd64"):
+            # 10 = len(".dll_amd64")
+            new_fname = fname[:-10] + ".dll"
             os.rename(fname, new_fname)
         else:
             new_fname = fname

--- a/recipe/vc_repack.py
+++ b/recipe/vc_repack.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import tempfile
 import xml.dom.minidom
-import glob
+from glob import glob
 
 # Requires m2-p7zip conda package on Windows
 # If cross-building on Linux, requires p7zip installed
@@ -249,14 +249,14 @@ def fix_filename_and_copy(source, dest):
     os.chdir(source)
     # as of VS 17.6, the artefact contains intermediate DLL extensions,
     # which get renamed correctly upon installation; do it manually
-    candidates = glob.glob("*.dll") + glob.glob("*.dll_amd64")
-    for fname in candidates:
+    dlls = glob("*.dll") + glob("*.dll_amd64") + glob("*.dll_arm64")
+    for fname in dlls:
         print(f"Found DLL: {fname}")
         if fname.startswith("api_"):
             new_fname = fname.replace("_", "-")
             os.rename(fname, new_fname)
-        elif fname.endswith(".dll_amd64"):
-            # 10 = len(".dll_amd64")
+        elif fname.endswith(".dll_amd64") or fname.endswith(".dll_arm64"):
+            # 10 == len(".dll_amd64") == len(".dll_arm64")
             new_fname = fname[:-10] + ".dll"
             os.rename(fname, new_fname)
         else:


### PR DESCRIPTION
Recently released...

I'm pretty sure we need this because the windows images have been updated, and we're getting lots of
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise>CALL "VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.34 10.0.22621.0 
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.6.2
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[ERROR:vcvars.bat] Toolset directory for version '14.34' was not found.
[ERROR:VsDevCmd.bat] *** VsDevCmd.bat encountered errors. Environment may be incomplete and/or incorrect. ***
[ERROR:VsDevCmd.bat] In an uninitialized command prompt, please 'set VSCMD_DEBUG=[value]' and then re-run
[ERROR:VsDevCmd.bat] vsdevcmd.bat [args] for additional details.
[ERROR:VsDevCmd.bat] Where [value] is:
[ERROR:VsDevCmd.bat]    1 : basic debug logging
[ERROR:VsDevCmd.bat]    2 : detailed debug logging
[ERROR:VsDevCmd.bat]    3 : trace level logging. Redirection of output to a file when using this level is recommended.
[ERROR:VsDevCmd.bat] Example: set VSCMD_DEBUG=3
[ERROR:VsDevCmd.bat]          vsdevcmd.bat > vsdevcmd.trace.txt 2>&1
```

AFAICT this has broken VS2022 in a few places, but since that's not our default the blast radius is not so big.

Xref discussion in #57, where the conclusion was that we need to match the cl_version with what's in the image.

Closes #63

