### PR TITLE
Include CMAKE_INSTALL_PREFIX in CMAKE_ARGS during activation

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -82,8 +82,7 @@ set "VCVARSBAT=@{vcvarsbat}"
 
 set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release"
 IF "%CONDA_BUILD%" == "1" (
-  set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%"
-  set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"
+  set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"
 )
 
 IF NOT "@{target_platform}" == "@{host_platform}" (

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@
 {% endif %}
 
 {% set vc_major = vcver.split(".")[0] %}
-{% set build_num = 16 %}
+{% set build_num = 17 %}
 
 package:
   name: vs{{ vsyear }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is a follow-up to PR #58. I tried to build a conda recipe on Windows using only `%CMAKE_ARGS%`. Strangely it didn't set `CMAKE_INSTALL_PREFIX` even though this is clearly intended to be set in `activate.bat`:

https://github.com/conda-forge/vc-feedstock/blob/3816e17c4df029e219f2768e524eca40e730b671/recipe/activate.bat#L83-L87

For some reason, it appears that the final line overwrites the previous ones even though they both start with `set "CMAKE_ARGS=%CMAKE_ARGS% ..."`. I don't understand this behavior, but I fixed it by combining them into a single line.

Here is a minimal reproducible example to demonstrate that `CMAKE_INSTALL_PREFIX` is lost:

```batch
@echo on

set "CONDA_BUILD=1"
set "LIBRARY_PREFIX=libpath"
set "BUILD_PREFIX=buildpath"
set "PREFIX=prefixpath"

set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release"
IF "%CONDA_BUILD%" == "1" (
  set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%"
  set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"
)

echo CMAKE_ARGS=%CMAKE_ARGS%
```

Then executing it with `call "test.bat"`

```
>set "CONDA_BUILD=1"

>set "LIBRARY_PREFIX=libpath"

>set "BUILD_PREFIX=buildpath"

>set "PREFIX=prefixpath"

>set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release"

>IF "1" == "1" (
set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=libpath"
 set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_PROGRAM_PATH=buildpath\bin;buildpath\Scripts;buildpath\Library\bin;prefixpath\bin;prefixpath\Scripts;prefixpath\Library\bin"
)

>echo CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_PROGRAM_PATH=buildpath\bin;buildpath\Scripts;buildpath\Library\bin;prefixpath\bin;prefixpath\Scripts;prefixpath\Library\bin
CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_PROGRAM_PATH=buildpath\bin;buildpath\Scripts;buildpath\Library\bin;prefixpath\bin;prefixpath\Scripts;prefixpath\Library\bin
```