### PR TITLE
upgrade to msvc 14.37

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,24 +18,19 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: win_arm64_cl_version19.29.30139cros_h5ab1bbeecd
-      win_arm64_cl_version19.36.32532cros_h0267430ae8:
-        CONFIG: win_arm64_cl_version19.36.32532cros_h0267430ae8
+      win_arm64_cl_version19.37.32822cros_h9bdb558ad7:
+        CONFIG: win_arm64_cl_version19.37.32822cros_h9bdb558ad7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: win_arm64_cl_version19.36.32532cros_h0267430ae8
-      win_arm64_cl_version19.36.32532cros_hd5bd5a4e25:
-        CONFIG: win_arm64_cl_version19.36.32532cros_hd5bd5a4e25
+        SHORT_CONFIG: win_arm64_cl_version19.37.32822cros_h9bdb558ad7
+      win_arm64_cl_version19.37.32822cros_ha1107d439d:
+        CONFIG: win_arm64_cl_version19.37.32822cros_ha1107d439d
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: win_arm64_cl_version19.36.32532cros_hd5bd5a4e25
+        SHORT_CONFIG: win_arm64_cl_version19.37.32822cros_ha1107d439d
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -16,14 +16,14 @@ jobs:
         CONFIG: win_64_cl_version19.29.30139cross_t_h16fbe5123a
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: win_64_cl_version19.29.30139cross_t_h16fbe5123a
-      win_64_cl_version19.36.32532cross_t_h23db042d00:
-        CONFIG: win_64_cl_version19.36.32532cross_t_h23db042d00
+      win_64_cl_version19.37.32822cross_t_h5bb07cb262:
+        CONFIG: win_64_cl_version19.37.32822cross_t_h5bb07cb262
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_cl_version19.36.32532cross_t_h23db042d00
-      win_64_cl_version19.36.32532cross_t_hc40340d1e0:
-        CONFIG: win_64_cl_version19.36.32532cross_t_hc40340d1e0
+        SHORT_CONFIG: win_64_cl_version19.37.32822cross_t_h5bb07cb262
+      win_64_cl_version19.37.32822cross_t_hb0fc03c3d5:
+        CONFIG: win_64_cl_version19.37.32822cross_t_hb0fc03c3d5
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_cl_version19.36.32532cross_t_hc40340d1e0
+        SHORT_CONFIG: win_64_cl_version19.37.32822cross_t_hb0fc03c3d5
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -73,7 +73,10 @@ jobs:
         if EXIST LICENSE.txt (
           copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
         )
-        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+          set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.ci_support/win_64_cl_version19.37.32822cross_t_h5bb07cb262.yaml
+++ b/.ci_support/win_64_cl_version19.37.32822cross_t_h5bb07cb262.yaml
@@ -3,19 +3,17 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.36.32532
+- 19.37.32822
 cross_target_platform:
 - win-arm64
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 runtime_version:
 - 14.36.32532
 sha256:
 - 37342E0ABDAEAE0297F64A889F842AC9453139639FB0178C0754A7D2F330043A
 target_platform:
-- win-arm64
+- win-64
 update_version:
-- '6'
+- '7'
 uuid:
 - eaab1f82-787d-4fd7-8c73-f782341a0c63
 vc:

--- a/.ci_support/win_64_cl_version19.37.32822cross_t_hb0fc03c3d5.yaml
+++ b/.ci_support/win_64_cl_version19.37.32822cross_t_hb0fc03c3d5.yaml
@@ -3,17 +3,17 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.36.32532
+- 19.37.32822
 cross_target_platform:
-- win-arm64
+- win-64
 runtime_version:
 - 14.36.32532
 sha256:
-- 37342E0ABDAEAE0297F64A889F842AC9453139639FB0178C0754A7D2F330043A
+- 917C37D816488545B70AFFD77D6E486E4DD27E2ECE63F6BBAAF486B178B2B888
 target_platform:
 - win-64
 update_version:
-- '6'
+- '7'
 uuid:
 - eaab1f82-787d-4fd7-8c73-f782341a0c63
 vc:

--- a/.ci_support/win_arm64_cl_version19.37.32822cros_h9bdb558ad7.yaml
+++ b/.ci_support/win_arm64_cl_version19.37.32822cros_h9bdb558ad7.yaml
@@ -3,17 +3,19 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.36.32532
+- 19.37.32822
 cross_target_platform:
 - win-64
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 runtime_version:
 - 14.36.32532
 sha256:
 - 917C37D816488545B70AFFD77D6E486E4DD27E2ECE63F6BBAAF486B178B2B888
 target_platform:
-- win-64
+- win-arm64
 update_version:
-- '6'
+- '7'
 uuid:
 - eaab1f82-787d-4fd7-8c73-f782341a0c63
 vc:

--- a/.ci_support/win_arm64_cl_version19.37.32822cros_ha1107d439d.yaml
+++ b/.ci_support/win_arm64_cl_version19.37.32822cros_ha1107d439d.yaml
@@ -3,19 +3,19 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.36.32532
+- 19.37.32822
 cross_target_platform:
-- win-64
+- win-arm64
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 runtime_version:
 - 14.36.32532
 sha256:
-- 917C37D816488545B70AFFD77D6E486E4DD27E2ECE63F6BBAAF486B178B2B888
+- 37342E0ABDAEAE0297F64A889F842AC9453139639FB0178C0754A7D2F330043A
 target_platform:
 - win-arm64
 update_version:
-- '6'
+- '7'
 uuid:
 - eaab1f82-787d-4fd7-8c73-f782341a0c63
 vc:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ About vc-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/vc-feedstock/blob/main/LICENSE.txt)
 
+
 About vc
 --------
 
@@ -11,6 +12,7 @@ Home: https://docs.microsoft.com/en-us/visualstudio/windows/?view=vs-
 Package license: LicenseRef-ProprietaryMicrosoft
 
 Summary: Activation and version verification of MSVC  (VS  compiler, update )
+
 About vs2022_win-arm64
 ----------------------
 
@@ -18,7 +20,8 @@ About vs2022_win-arm64
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 6)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 7)
+
 About vs_win-arm64
 ------------------
 
@@ -26,7 +29,8 @@ About vs_win-arm64
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 6)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 7)
+
 About vc14_runtime
 ------------------
 
@@ -34,15 +38,17 @@ Home: https://visualstudio.microsoft.com/downloads/
 
 Package license: LicenseRef-ProprietaryMicrosoft
 
-Summary: MSVC runtimes associated with cl.exe version 19.36.32532 (VS 2022 update 6)
-About vs2022_win-64
+Summary: MSVC runtimes associated with cl.exe version 19.37.32822 (VS 2022 update 7)
+
+About vs2019_win-64
 -------------------
 
 
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 6)
+Summary: Activation and version verification of MSVC 14.2 (VS 2019 compiler, update 11)
+
 About vc
 --------
 
@@ -57,6 +63,7 @@ Development: https://github.com/conda/conda/wiki/VC-features
 Documentation: https://github.com/conda/conda/wiki/VC-features
 
 This metapackage is used to enforce consistency of runtime dependencies within an environment
+
 About vs2015_runtime
 --------------------
 
@@ -65,6 +72,7 @@ Home: https://github.com/conda-forge/vc-feedstock
 Package license: BSD-3-Clause
 
 Summary: A backwards compatible meta-package. See vc14_runtime for the new package.
+
 About vs_win-64
 ---------------
 
@@ -72,7 +80,8 @@ About vs_win-64
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.2 (VS 2019 compiler, update 11)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 7)
+
 About vs2017_win-64
 -------------------
 
@@ -81,14 +90,15 @@ About vs2017_win-64
 Package license: BSD-3-Clause
 
 Summary: Activation and version verification of MSVC 14.1 (VS 2017 compiler, update 9)
-About vs2019_win-64
+
+About vs2022_win-64
 -------------------
 
 
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.2 (VS 2019 compiler, update 11)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 7)
 
 Current build status
 ====================
@@ -122,17 +132,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cl_version19.36.32532cross_t_h23db042d00</td>
+              <td>win_64_cl_version19.37.32822cross_t_h5bb07cb262</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.36.32532cross_t_h23db042d00" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.37.32822cross_t_h5bb07cb262" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cl_version19.36.32532cross_t_hc40340d1e0</td>
+              <td>win_64_cl_version19.37.32822cross_t_hb0fc03c3d5</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.36.32532cross_t_hc40340d1e0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.37.32822cross_t_hb0fc03c3d5" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -150,17 +160,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_arm64_cl_version19.36.32532cros_h0267430ae8</td>
+              <td>win_arm64_cl_version19.37.32822cros_h9bdb558ad7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.36.32532cros_h0267430ae8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.37.32822cros_h9bdb558ad7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_arm64_cl_version19.36.32532cros_hd5bd5a4e25</td>
+              <td>win_arm64_cl_version19.37.32822cros_ha1107d439d</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.36.32532cros_hd5bd5a4e25" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.37.32822cros_ha1107d439d" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -24,14 +24,14 @@ runtime_version:
 # reported in the VS help->about UI.  It is perhaps a more readily
 # referenceable number.
 update_version:
- - 6
- - 6
+ - 7
+ - 7
  - 11
  - 9
 # This is the version number reported by cl.exe
 cl_version:
- - 19.36.32532
- - 19.36.32532
+ - 19.37.32822
+ - 19.37.32822
  - 19.29.30139
  - 19.16.27033
 # This is the uuid in the URL; redirect can be resolved e.g. as follows


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #67 

Note that the version of MSVC runtime still at `14.36.32532`. The `cl` compiler version has been upgraded to `19.37.32822` and the toolchain version is `14.37.32822`, which is needed in the command call of `vcvars64.bat -vcvars_ver=`.