### PR TITLE
VS 17.10; == VS2022 Update 10

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,16 +18,6 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: win_arm64_cl_version19.29.30139cros_h5ab1bbeecd
-      win_arm64_cl_version19.38.33135cros_h3580540fb0:
-        CONFIG: win_arm64_cl_version19.38.33135cros_h3580540fb0
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: win_arm64_cl_version19.38.33135cros_h3580540fb0
-      win_arm64_cl_version19.38.33135cros_hb61b9606b2:
-        CONFIG: win_arm64_cl_version19.38.33135cros_hb61b9606b2
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: win_arm64_cl_version19.38.33135cros_hb61b9606b2
       win_arm64_cl_version19.39.33519cros_h835692272b:
         CONFIG: win_arm64_cl_version19.39.33519cros_h835692272b
         UPLOAD_PACKAGES: 'True'
@@ -38,6 +28,16 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: win_arm64_cl_version19.39.33519cros_h9c25a1236d
+      win_arm64_cl_version19.40.33808cros_h7173afee75:
+        CONFIG: win_arm64_cl_version19.40.33808cros_h7173afee75
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: win_arm64_cl_version19.40.33808cros_h7173afee75
+      win_arm64_cl_version19.40.33808cros_h98edac65ce:
+        CONFIG: win_arm64_cl_version19.40.33808cros_h98edac65ce
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: win_arm64_cl_version19.40.33808cros_h98edac65ce
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -16,14 +16,6 @@ jobs:
         CONFIG: win_64_cl_version19.29.30139cross_t_h16fbe5123a
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: win_64_cl_version19.29.30139cross_t_h16fbe5123a
-      win_64_cl_version19.38.33135cross_t_h3695ef549d:
-        CONFIG: win_64_cl_version19.38.33135cross_t_h3695ef549d
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_cl_version19.38.33135cross_t_h3695ef549d
-      win_64_cl_version19.38.33135cross_t_hf0501d5fd2:
-        CONFIG: win_64_cl_version19.38.33135cross_t_hf0501d5fd2
-        UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: win_64_cl_version19.38.33135cross_t_hf0501d5fd2
       win_64_cl_version19.39.33519cross_t_h0df7bd75cc:
         CONFIG: win_64_cl_version19.39.33519cross_t_h0df7bd75cc
         UPLOAD_PACKAGES: 'True'
@@ -32,6 +24,14 @@ jobs:
         CONFIG: win_64_cl_version19.39.33519cross_t_h94575db908
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: win_64_cl_version19.39.33519cross_t_h94575db908
+      win_64_cl_version19.40.33808cross_t_h0d7d6ff254:
+        CONFIG: win_64_cl_version19.40.33808cross_t_h0d7d6ff254
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_cl_version19.40.33808cross_t_h0d7d6ff254
+      win_64_cl_version19.40.33808cross_t_h50d9fe5020:
+        CONFIG: win_64_cl_version19.40.33808cross_t_h50d9fe5020
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_cl_version19.40.33808cross_t_h50d9fe5020
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/win_64_cl_version19.40.33808cross_t_h0d7d6ff254.yaml
+++ b/.ci_support/win_64_cl_version19.40.33808cross_t_h0d7d6ff254.yaml
@@ -3,19 +3,19 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.38.33135
+- 19.40.33808
 cross_target_platform:
-- win-arm64
+- win-64
 runtime_version:
-- 14.38.33130
+- 14.40.33810
 sha256:
-- BAC344CBC947DB8E306986BFB45A33052E1AAEE8F104ADBD9E461EB8199E27D2
+- 3642E3F95D50CC193E4B5A0B0FFBF7FE2C08801517758B4C8AEB7105A091208A
 target_platform:
 - win-64
 update_version:
-- '8'
+- '10'
 uuid:
-- a061be25-c14a-489a-8c7c-bb72adfb3cab
+- 1754ea58-11a6-44ab-a262-696e194ce543
 vc:
 - '14'
 vcver:

--- a/.ci_support/win_64_cl_version19.40.33808cross_t_h50d9fe5020.yaml
+++ b/.ci_support/win_64_cl_version19.40.33808cross_t_h50d9fe5020.yaml
@@ -3,19 +3,19 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.38.33135
+- 19.40.33808
 cross_target_platform:
-- win-64
+- win-arm64
 runtime_version:
-- 14.38.33130
+- 14.40.33810
 sha256:
-- 4DFE83C91124CD542F4222FE2C396CABEAC617BB6F59BDCBDF89FD6F0DF0A32F
+- 15B8F5B2106DC7A7BD83AB57B796770E0F4ECB891AD19BF655C9D6A9DA650AD2
 target_platform:
 - win-64
 update_version:
-- '8'
+- '10'
 uuid:
-- a061be25-c14a-489a-8c7c-bb72adfb3cab
+- 1754ea58-11a6-44ab-a262-696e194ce543
 vc:
 - '14'
 vcver:

--- a/.ci_support/win_arm64_cl_version19.40.33808cros_h7173afee75.yaml
+++ b/.ci_support/win_arm64_cl_version19.40.33808cros_h7173afee75.yaml
@@ -3,21 +3,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.38.33135
+- 19.40.33808
 cross_target_platform:
-- win-64
+- win-arm64
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 runtime_version:
-- 14.38.33130
+- 14.40.33810
 sha256:
-- 4DFE83C91124CD542F4222FE2C396CABEAC617BB6F59BDCBDF89FD6F0DF0A32F
+- 15B8F5B2106DC7A7BD83AB57B796770E0F4ECB891AD19BF655C9D6A9DA650AD2
 target_platform:
 - win-arm64
 update_version:
-- '8'
+- '10'
 uuid:
-- a061be25-c14a-489a-8c7c-bb72adfb3cab
+- 1754ea58-11a6-44ab-a262-696e194ce543
 vc:
 - '14'
 vcver:

--- a/.ci_support/win_arm64_cl_version19.40.33808cros_h98edac65ce.yaml
+++ b/.ci_support/win_arm64_cl_version19.40.33808cros_h98edac65ce.yaml
@@ -3,21 +3,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cl_version:
-- 19.38.33135
+- 19.40.33808
 cross_target_platform:
-- win-arm64
+- win-64
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 runtime_version:
-- 14.38.33130
+- 14.40.33810
 sha256:
-- BAC344CBC947DB8E306986BFB45A33052E1AAEE8F104ADBD9E461EB8199E27D2
+- 3642E3F95D50CC193E4B5A0B0FFBF7FE2C08801517758B4C8AEB7105A091208A
 target_platform:
 - win-arm64
 update_version:
-- '8'
+- '10'
 uuid:
-- a061be25-c14a-489a-8c7c-bb72adfb3cab
+- 1754ea58-11a6-44ab-a262-696e194ce543
 vc:
 - '14'
 vcver:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ About vs2022_win-arm64
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 8)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 9)
 
 About vs_win-arm64
 ------------------
@@ -29,7 +29,7 @@ About vs_win-arm64
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 8)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 9)
 
 About vc14_runtime
 ------------------
@@ -38,7 +38,7 @@ Home: https://visualstudio.microsoft.com/downloads/
 
 Package license: LicenseRef-ProprietaryMicrosoft
 
-Summary: MSVC runtimes associated with cl.exe version 19.38.33135 (VS 2022 update 8)
+Summary: MSVC runtimes associated with cl.exe version 19.39.33519 (VS 2022 update 9)
 
 About vs2022_win-64
 -------------------
@@ -47,7 +47,7 @@ About vs2022_win-64
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 9)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 10)
 
 About vc
 --------
@@ -80,15 +80,6 @@ About vs_win-64
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 9)
-
-About vs2019_win-64
--------------------
-
-
-
-Package license: BSD-3-Clause
-
 Summary: Activation and version verification of MSVC 14.2 (VS 2019 compiler, update 11)
 
 About vs2017_win-64
@@ -99,6 +90,15 @@ About vs2017_win-64
 Package license: BSD-3-Clause
 
 Summary: Activation and version verification of MSVC 14.1 (VS 2017 compiler, update 9)
+
+About vs2019_win-64
+-------------------
+
+
+
+Package license: BSD-3-Clause
+
+Summary: Activation and version verification of MSVC 14.2 (VS 2019 compiler, update 11)
 
 Current build status
 ====================
@@ -132,20 +132,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cl_version19.38.33135cross_t_h3695ef549d</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.38.33135cross_t_h3695ef549d" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_64_cl_version19.38.33135cross_t_hf0501d5fd2</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.38.33135cross_t_hf0501d5fd2" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>win_64_cl_version19.39.33519cross_t_h0df7bd75cc</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
@@ -157,6 +143,20 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.39.33519cross_t_h94575db908" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cl_version19.40.33808cross_t_h0d7d6ff254</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.40.33808cross_t_h0d7d6ff254" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cl_version19.40.33808cross_t_h50d9fe5020</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cl_version19.40.33808cross_t_h50d9fe5020" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -174,20 +174,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_arm64_cl_version19.38.33135cros_h3580540fb0</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.38.33135cros_h3580540fb0" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_arm64_cl_version19.38.33135cros_hb61b9606b2</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.38.33135cros_hb61b9606b2" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>win_arm64_cl_version19.39.33519cros_h835692272b</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
@@ -199,6 +185,20 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.39.33519cros_h9c25a1236d" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_arm64_cl_version19.40.33808cros_h7173afee75</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.40.33808cros_h7173afee75" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_arm64_cl_version19.40.33808cros_h98edac65ce</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3629&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/vc-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_cl_version19.40.33808cros_h98edac65ce" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -19,48 +19,51 @@ vsver:
  - 17
  - 16
  - 15
+# vc_repack.py checks the expected runtime version (which can be used to find out of course)
 runtime_version:
  # the azure/github images only contain the latest minor version per vs-line;
  # if there is a use-case for having older minor versions, they can be added when requested.
+ - 14.40.33810
+ - 14.40.33810
  - 14.38.33135
  - 14.38.33135
- - 14.38.33130
- - 14.38.33130
  - 14.29.30139
  - 14.16.27033
 # the VS update version.  This is the middle digit in the version
 # reported in the VS help->about UI.  It is perhaps a more readily
 # referenceable number.
 update_version:
+ - 10
+ - 10
  - 9
  - 9
- - 8
- - 8
  - 11
  - 9
-# This is the version number reported by cl.exe
+# This is the version number reported by cl.exe; if you don't want to or cannot download,
+# candidates can be found with a github code search (adapt minor number as necessary):
+# https://github.com/search?q=%2F19%5C.40%5C.3%5Cd%5Cd%5Cd%5Cd%2F&type=code
 cl_version:
+ - 19.40.33808
+ - 19.40.33808
  - 19.39.33519
  - 19.39.33519
- - 19.38.33135
- - 19.38.33135
  - 19.29.30139
  - 19.16.27033
 # This is the uuid in the URL; redirect can be resolved e.g. as follows
 # curl -ILSs https://aka.ms/vs/17/release/vc_redist.x64.exe | grep "Location:"
 # curl -ILSs https://aka.ms/vs/17/release/vc_redist.arm64.exe | grep "Location:"
 uuid:
+ - 1754ea58-11a6-44ab-a262-696e194ce543
+ - 1754ea58-11a6-44ab-a262-696e194ce543
  - 71c6392f-8df5-4b61-8d50-dba6a525fb9d
  - c7707d68-d6ce-4479-973e-e2a3dc4341fe
- - a061be25-c14a-489a-8c7c-bb72adfb3cab
- - a061be25-c14a-489a-8c7c-bb72adfb3cab
  - b929b7fe-5c89-4553-9abe-6324631dcc3a
  - 4100b84d-1b4d-487d-9f89-1354a7138c8f
 sha256:
+ - 15B8F5B2106DC7A7BD83AB57B796770E0F4ECB891AD19BF655C9D6A9DA650AD2
+ - 3642E3F95D50CC193E4B5A0B0FFBF7FE2C08801517758B4C8AEB7105A091208A
  - 9378E04AE461E29CE5E46787D20F81700C80AD305B9417710D147C1D7FF0C970
  - 1AD7988C17663CC742B01BEF1A6DF2ED1741173009579AD50A94434E54F56073
- - BAC344CBC947DB8E306986BFB45A33052E1AAEE8F104ADBD9E461EB8199E27D2
- - 4DFE83C91124CD542F4222FE2C396CABEAC617BB6F59BDCBDF89FD6F0DF0A32F
  - 296F96CD102250636BCD23AB6E6CF70935337B1BBB3507FE8521D8D9CFAA932F
  - 5B0CBB977F2F5253B1EBE5C9D30EDBDA35DBD68FB70DE7AF5FAAC6423DB575B5
 cross_target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -225,7 +225,7 @@ outputs:
       license: BSD-3-Clause
 
   - name: vs_{{ cross_target_platform }}
-    version: {{ vsyear }}.{{ update_version }}
+    version: "{{ vsyear }}.{{ update_version }}"
     build:
       track_features:
         - vc{{ vc_major }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -146,6 +146,8 @@ outputs:
     requirements:
       run:
         - vc{{ vc_major }}_runtime >={{ runtime_version }}
+    test:
+      commands: echo "this is an empty wrapper package"
     about:
       home: https://github.com/conda-forge/vc-feedstock
       license: BSD-3-Clause
@@ -167,6 +169,8 @@ outputs:
         # compiler: assume that when vcver's major version changes,
         # MSFT has broken our binary compatibility.
         - vc{{ vc_major }}_runtime >={{ runtime_version }}
+    test:
+      commands: echo "this is an empty wrapper package"
     about:
       home: https://github.com/conda/conda/wiki/VC-features
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@
 {% if vsyear is not defined %}
 {% set vsyear = "" %}
 {% set runtime_version = "" %}
-{% set cl_version = "19.39" %}
+{% set cl_version = "19.40" %}
 {% set vcver = "" %}
 {% endif %}
 


### PR DESCRIPTION
Fixes #72, though there might be more places we have to update; for now I'm keeping `vcver` at `14.3`, [due to](https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/)
> The C++ Project System (MS Build) is being updated to support ‘14.4x’ MSVC toolsets under the v143 Platform Toolset.

Needs to wait for:
* [x] CMake [3.29.4](https://github.com/conda-forge/cmake-feedstock/pull/215), which contains a couple relevant [fixes](https://gitlab.kitware.com/cmake/cmake/-/milestones/149).
* [x] 17.40 in Azure [images](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#visual-studio-enterprise-2022)