### PR TITLE
also update INCLUDE/LIB when not building packages

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,47 +11,47 @@ jobs:
       win_arm64_cl_version19.29.30139cros_h5ab1bbeecd:
         CONFIG: win_arm64_cl_version19.29.30139cros_h5ab1bbeecd
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.29.30139cros_h5ab1bbeecd
       win_arm64_cl_version19.39.33519cros_h835692272b:
         CONFIG: win_arm64_cl_version19.39.33519cros_h835692272b
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.39.33519cros_h835692272b
       win_arm64_cl_version19.39.33519cros_h9c25a1236d:
         CONFIG: win_arm64_cl_version19.39.33519cros_h9c25a1236d
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.39.33519cros_h9c25a1236d
       win_arm64_cl_version19.40.33808cros_h7173afee75:
         CONFIG: win_arm64_cl_version19.40.33808cros_h7173afee75
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.40.33808cros_h7173afee75
       win_arm64_cl_version19.40.33808cros_h98edac65ce:
         CONFIG: win_arm64_cl_version19.40.33808cros_h98edac65ce
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.40.33808cros_h98edac65ce
       win_arm64_cl_version19.41.34120cros_hf07a69c0f6:
         CONFIG: win_arm64_cl_version19.41.34120cros_hf07a69c0f6
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.41.34120cros_hf07a69c0f6
       win_arm64_cl_version19.41.34120cros_hfcbbf4eb76:
         CONFIG: win_arm64_cl_version19.41.34120cros_hfcbbf4eb76
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.41.34120cros_hfcbbf4eb76
       win_arm64_cl_version19.42.34433cros_h380eed0bef:
         CONFIG: win_arm64_cl_version19.42.34433cros_h380eed0bef
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.42.34433cros_h380eed0bef
       win_arm64_cl_version19.42.34433cros_h8dce34b965:
         CONFIG: win_arm64_cl_version19.42.34433cros_h8dce34b965
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
         SHORT_CONFIG: win_arm64_cl_version19.42.34433cros_h8dce34b965
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -57,6 +57,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/win_64_cl_version19.29.30139cross_t_h16fbe5123a.yaml
+++ b/.ci_support/win_64_cl_version19.29.30139cross_t_h16fbe5123a.yaml
@@ -16,8 +16,6 @@ update_version:
 - '11'
 uuid:
 - b929b7fe-5c89-4553-9abe-6324631dcc3a
-vc:
-- '14'
 vcver:
 - '14.2'
 vsver:

--- a/.ci_support/win_64_cl_version19.39.33519cross_t_h0df7bd75cc.yaml
+++ b/.ci_support/win_64_cl_version19.39.33519cross_t_h0df7bd75cc.yaml
@@ -16,8 +16,6 @@ update_version:
 - '9'
 uuid:
 - c7707d68-d6ce-4479-973e-e2a3dc4341fe
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_64_cl_version19.39.33519cross_t_h94575db908.yaml
+++ b/.ci_support/win_64_cl_version19.39.33519cross_t_h94575db908.yaml
@@ -16,8 +16,6 @@ update_version:
 - '9'
 uuid:
 - 71c6392f-8df5-4b61-8d50-dba6a525fb9d
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_64_cl_version19.40.33808cross_t_h0d7d6ff254.yaml
+++ b/.ci_support/win_64_cl_version19.40.33808cross_t_h0d7d6ff254.yaml
@@ -16,8 +16,6 @@ update_version:
 - '10'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_64_cl_version19.40.33808cross_t_h50d9fe5020.yaml
+++ b/.ci_support/win_64_cl_version19.40.33808cross_t_h50d9fe5020.yaml
@@ -16,8 +16,6 @@ update_version:
 - '10'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_64_cl_version19.41.34120cross_t_hce58adb501.yaml
+++ b/.ci_support/win_64_cl_version19.41.34120cross_t_hce58adb501.yaml
@@ -16,8 +16,6 @@ update_version:
 - '11'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_64_cl_version19.41.34120cross_t_hd9d6fca87a.yaml
+++ b/.ci_support/win_64_cl_version19.41.34120cross_t_hd9d6fca87a.yaml
@@ -16,8 +16,6 @@ update_version:
 - '11'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_64_cl_version19.42.34433cross_t_h89dbb0e25e.yaml
+++ b/.ci_support/win_64_cl_version19.42.34433cross_t_h89dbb0e25e.yaml
@@ -16,8 +16,6 @@ update_version:
 - '12'
 uuid:
 - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_64_cl_version19.42.34433cross_t_hefdc3107f9.yaml
+++ b/.ci_support/win_64_cl_version19.42.34433cross_t_hefdc3107f9.yaml
@@ -16,8 +16,6 @@ update_version:
 - '12'
 uuid:
 - 5319f718-2a84-4aff-86be-8dbdefd92ca1
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.29.30139cros_h5ab1bbeecd.yaml
+++ b/.ci_support/win_arm64_cl_version19.29.30139cros_h5ab1bbeecd.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.29.30139
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '11'
 uuid:
 - b929b7fe-5c89-4553-9abe-6324631dcc3a
-vc:
-- '14'
 vcver:
 - '14.2'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.39.33519cros_h835692272b.yaml
+++ b/.ci_support/win_arm64_cl_version19.39.33519cros_h835692272b.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.38.33135
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '9'
 uuid:
 - c7707d68-d6ce-4479-973e-e2a3dc4341fe
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.39.33519cros_h9c25a1236d.yaml
+++ b/.ci_support/win_arm64_cl_version19.39.33519cros_h9c25a1236d.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-arm64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.38.33135
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '9'
 uuid:
 - 71c6392f-8df5-4b61-8d50-dba6a525fb9d
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.40.33808cros_h7173afee75.yaml
+++ b/.ci_support/win_arm64_cl_version19.40.33808cros_h7173afee75.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-arm64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.40.33810
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '10'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.40.33808cros_h98edac65ce.yaml
+++ b/.ci_support/win_arm64_cl_version19.40.33808cros_h98edac65ce.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.40.33810
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '10'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.41.34120cros_hf07a69c0f6.yaml
+++ b/.ci_support/win_arm64_cl_version19.41.34120cros_hf07a69c0f6.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-arm64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.40.33810
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '11'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.41.34120cros_hfcbbf4eb76.yaml
+++ b/.ci_support/win_arm64_cl_version19.41.34120cros_hfcbbf4eb76.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.40.33810
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '11'
 uuid:
 - 1754ea58-11a6-44ab-a262-696e194ce543
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.42.34433cros_h380eed0bef.yaml
+++ b/.ci_support/win_arm64_cl_version19.42.34433cros_h380eed0bef.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.42.34433
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '12'
 uuid:
 - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.ci_support/win_arm64_cl_version19.42.34433cros_h8dce34b965.yaml
+++ b/.ci_support/win_arm64_cl_version19.42.34433cros_h8dce34b965.yaml
@@ -7,7 +7,7 @@ cl_version:
 cross_target_platform:
 - win-arm64
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 runtime_version:
 - 14.42.34433
 sha256:
@@ -18,8 +18,6 @@ update_version:
 - '12'
 uuid:
 - 5319f718-2a84-4aff-86be-8dbdefd92ca1
-vc:
-- '14'
 vcver:
 - '14.3'
 vsver:

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/README.md
+++ b/README.md
@@ -13,24 +13,6 @@ Package license: LicenseRef-ProprietaryMicrosoft
 
 Summary: Activation and version verification of MSVC  (VS  compiler, update update_version)
 
-About vs2022_win-arm64
-----------------------
-
-
-
-Package license: BSD-3-Clause
-
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 12)
-
-About vs_win-arm64
-------------------
-
-
-
-Package license: BSD-3-Clause
-
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 12)
-
 About vc14_runtime
 ------------------
 
@@ -40,14 +22,14 @@ Package license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
 
 Summary: MSVC runtimes associated with cl.exe version 19.42.34433 (VS 2022 update 12)
 
-About vs2022_win-64
+About vs2019_win-64
 -------------------
 
 
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 12)
+Summary: Activation and version verification of MSVC 14.2 (VS 2019 compiler, update 11)
 
 About vc
 --------
@@ -80,16 +62,34 @@ About vs_win-64
 
 Package license: BSD-3-Clause
 
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 11)
+
+About vs2022_win-arm64
+----------------------
+
+
+
+Package license: BSD-3-Clause
+
 Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 12)
 
-About vs2019_win-64
+About vs_win-arm64
+------------------
+
+
+
+Package license: BSD-3-Clause
+
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 12)
+
+About vs2022_win-64
 -------------------
 
 
 
 Package license: BSD-3-Clause
 
-Summary: Activation and version verification of MSVC 14.2 (VS 2019 compiler, update 11)
+Summary: Activation and version verification of MSVC 14.3 (VS 2022 compiler, update 11)
 
 Current build status
 ====================

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -61,9 +61,15 @@ set "VSINSTALLDIR=%ProgramFiles(x86)%\Microsoft Visual Studio\@{year}\Enterprise
 )
 
 IF NOT "%CONDA_BUILD%" == "" (
+  :: building packages
   set "INCLUDE=%LIBRARY_INC%;%INCLUDE%"
   set "LIB=%LIBRARY_LIB%;%LIB%"
   set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
+) else (
+  :: normal environment
+  set "INCLUDE=%CONDA_PREFIX%\Library\include;%INCLUDE%"
+  set "LIB=%CONDA_PREFIX%\Library\lib;%LIB%"
+  set "CMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library;%CMAKE_PREFIX_PATH%"
 )
 
 
@@ -101,7 +107,7 @@ IF @{year} GEQ 2019  (
 ) ELSE (
     IF "@{target_platform}" == "win-64" (
         set "CMAKE_GEN=Visual Studio @{ver} @{year} Win64"
-	) else (
+    ) else (
         set "CMAKE_GEN=Visual Studio @{ver} @{year}"
     )
     set "USE_NEW_CMAKE_GEN_SYNTAX=0"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@
 {% set vcvars_ver_maj = cl_version.split(".")[0]|int - 5 %}
 {% set vcvars_ver_min = cl_version.split(".")[1]|int %}
 {% set vcvars_ver = vcvars_ver_maj ~ "." ~ vcvars_ver_min %}
-{% set build_num = 23 %}
+{% set build_num = 24 %}
 
 package:
   name: vs{{ vsyear }}


### PR DESCRIPTION
In https://github.com/conda-forge/pytorch-cpu-feedstock/pull/328, we want to move the library portion of `pytorch` (including the import libraries) to `%LIBRARY_LIB%` (to fix https://github.com/conda-forge/pytorch-cpu-feedstock/issues/327); however, there are some pytorch compilation tests that then won't find those libs, because they're not looking in that directory by default. 

This is in contrast to our compilers on UNIX, which add `$PREFIX/lib` to `LDFLAGS` [not just for](https://github.com/conda-forge/ctng-compiler-activation-feedstock/blob/987224ce91e63faf248a07619009a3049034d8e4/recipe/activate-gcc.sh#L89-L104) building packages, but also when activated compilers are in a regular environment (which is the case when we're running tests for pytorch, for example).

So mirror the setup from GCC here, which would allow us to fully move all the import libraries for `libtorch` to `%LIBRARY_LIB%`, without having to patch individual dependent packages to look in there specifically.

