### PR TITLE
Fix CMAKE_ARGS variable expansion

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -92,7 +92,7 @@ set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release"
 IF "%CONDA_BUILD%" == "1" (
   set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"
   :: see https://github.com/conda-forge/conda-smithy/issues/2319
-  set "CMAKE_ARGS=%CMAKE_ARGS% -DPython_FIND_REGISTRY=NEVER -DPython3_FIND_REGISTRY=NEVER"
+  set "CMAKE_ARGS=!CMAKE_ARGS! -DPython_FIND_REGISTRY=NEVER -DPython3_FIND_REGISTRY=NEVER"
 )
 
 IF NOT "@{target_platform}" == "@{host_platform}" (

--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,4 +1,5 @@
 @@echo on
+setlocal EnableDelayedExpansion
 
 :: Set env vars that tell distutils to use the compiler that we put on path
 SET DISTUTILS_USE_SDK=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@
 {% set vcvars_ver_maj = cl_version.split(".")[0]|int - 5 %}
 {% set vcvars_ver_min = cl_version.split(".")[1]|int %}
 {% set vcvars_ver = vcvars_ver_maj ~ "." ~ vcvars_ver_min %}
-{% set build_num = 28 %}
+{% set build_num = 29 %}
 
 package:
   name: vs{{ vsyear }}


### PR DESCRIPTION
#99 broke the `CMAKE_ARGS` value, as new variable set [here](https://github.com/h-vetinari/vc-feedstock/blob/4f9e21e419d033c2be327139017808b79dfec631/recipe/activate.bat#L94) causes to invalidate previous set [here](https://github.com/h-vetinari/vc-feedstock/blob/4f9e21e419d033c2be327139017808b79dfec631/recipe/activate.bat#L92). Then, the `CMAKE_ARGS` variable does not contain anymore the `CMAKE_INSTALL_PREFIX` and so values.
This looks most probably due to the lack of delayed variable expansion in the bat file.

Thanks to @jorisv for the help on this investigation.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
