### PR TITLE
update CMAKE_ARGS in one go in activate.bat

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,5 +1,4 @@
 @@echo on
-setlocal EnableDelayedExpansion
 
 :: Set env vars that tell distutils to use the compiler that we put on path
 SET DISTUTILS_USE_SDK=1
@@ -90,9 +89,8 @@ set "VCVARSBAT=@{vcvarsbat}"
 
 set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release"
 IF "%CONDA_BUILD%" == "1" (
-  set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"
-  :: see https://github.com/conda-forge/conda-smithy/issues/2319
-  set "CMAKE_ARGS=!CMAKE_ARGS! -DPython_FIND_REGISTRY=NEVER -DPython3_FIND_REGISTRY=NEVER"
+  :: for -DPython_FIND_REGISTRY see https://github.com/conda-forge/conda-smithy/issues/2319
+  set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DPython_FIND_REGISTRY=NEVER -DPython3_FIND_REGISTRY=NEVER -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"
 )
 
 IF NOT "@{target_platform}" == "@{host_platform}" (

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@
 {% set vcvars_ver_maj = cl_version.split(".")[0]|int - 5 %}
 {% set vcvars_ver_min = cl_version.split(".")[1]|int %}
 {% set vcvars_ver = vcvars_ver_maj ~ "." ~ vcvars_ver_min %}
-{% set build_num = 29 %}
+{% set build_num = 30 %}
 
 package:
   name: vs{{ vsyear }}


### PR DESCRIPTION
In https://github.com/conda-forge/wxwidgets-feedstock/pull/61 there's something very strange. The value of CMAKE_ARGS appears to get set correctly in activation
```
(%BUILD_PREFIX%) %SRC_DIR%>IF "1" == "1" (
set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX%\Library -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"  
 set "CMAKE_ARGS=!CMAKE_ARGS! -DPython_FIND_REGISTRY=NEVER -DPython3_FIND_REGISTRY=NEVER" 
) 

(%BUILD_PREFIX%) %SRC_DIR%>IF NOT "win-64" == "win-64" (
set "CONDA_BUILD_CROSS_COMPILATION=1"  
 set "CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX%\Library -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin -DPython_FIND_REGISTRY=NEVER -DPython3_FIND_REGISTRY=NEVER -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=AMD64" 
)  else (set "CONDA_BUILD_CROSS_COMPILATION=0" ) 
```
(note: the second branch here is not taken, but I've pasted it because it shows the previously set value of CMAKE_ARGS)

but then when the build is invoked, `CMAKE_ARGS` is empty
```
(%BUILD_PREFIX%) %SRC_DIR%\build_>cmake <CMAKE_ARGS_SHOULD_BE_HERE>  -GNinja     -DCMAKE_INSTALL_PREFIX=%PREFIX%\Library     -DwxUSE_REGEX=sys       -DwxUSE_ZLIB=sys        -DwxUSE_EXPAT=sys       -DwxUSE_LIBJPEG=sys     -DwxUSE_LIBPNG=sys      -DwxUSE_LIBTIFF=sys     -DwxUSE_LIBLZMA=sys     -DwxBUILD_VENDOR=     .. 
-- Setting build type to 'Debug' as none was specified.         # should be 'Release'!
```

So instead of putting `-DPython_FIND_REGISTRY=...` on a separate line as done in #99 and fixed up in #101, let's just update it in one go.

Sorry for the thrashing, batch files are an apparently endless source of insanity that keeps uppercutting my jaw.