### PR TITLE
Try deactivation again

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -1,3 +1,18 @@
+@@echo off
+setlocal enabledelayedexpansion
+
+:: save existing variables for deactivation script
+for %%X in (
+    CC CXX CMAKE_ARGS CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM CMAKE_GENERATOR_TOOLSET
+    CMAKE_PREFIX_PATH CONDA_BUILD_CROSS_COMPILATION DISTUTILS_USE_SDK INCLUDE
+    LIB MSSdk MSYS2_ARG_CONV_EXCL MSYS2_ENV_CONV_EXCL PY_VCRUNTIME_REDIST
+    VCVARSBAT VS_MAJOR VS_VERSION VS_YEAR VSINSTALLDIR WindowsSDKVer
+) do (
+    if defined %%X (
+        set "_CONDA_BACKUP_%%X=!%%X!"
+    )
+)
+
 @@echo on
 
 :: Set env vars that tell distutils to use the compiler that we put on path
@@ -185,6 +200,13 @@ IF NOT "@{target_platform}" == "@{host_platform}" (
 ) else (
   set "CONDA_BUILD_CROSS_COMPILATION=0"
 )
+
+:: unset auxiliary variables
+set "CMAKE_GEN="
+set "CMAKE_PLAT="
+set "LATEST_VS="
+set "NEWER_VS_WITH_OLDER_VC="
+set "USE_NEW_CMAKE_GEN_SYNTAX="
 
 :GetWin10SdkDir
 call :GetWin10SdkDirHelper HKLM\SOFTWARE\Wow6432Node > nul 2>&1

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,17 @@
+@@echo off
+setlocal enabledelayedexpansion
+
+:: restore variables
+for %%X in (
+    CC CXX CMAKE_ARGS CMAKE_GENERATOR CMAKE_GENERATOR_PLATFORM CMAKE_GENERATOR_TOOLSET
+    CMAKE_PREFIX_PATH CONDA_BUILD_CROSS_COMPILATION DISTUTILS_USE_SDK INCLUDE
+    LIB MSSdk MSYS2_ARG_CONV_EXCL MSYS2_ENV_CONV_EXCL PY_VCRUNTIME_REDIST
+    VCVARSBAT VS_MAJOR VS_VERSION VS_YEAR VSINSTALLDIR WindowsSDKVer
+) do (
+    if defined _CONDA_BACKUP_%%X (
+        set "%%X=!_CONDA_BACKUP_%%X!"
+        set "_CONDA_BACKUP_%%X="
+    ) else (
+        set "%%X="
+    )
+)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -270,6 +270,11 @@ outputs:
         - echo "%CMAKE_GENERATOR%"
         - echo "%CMAKE_GENERATOR_PLATFORM%"
         - echo "%CMAKE_GENERATOR_TOOLSET%"
+      # compare https://github.com/conda-forge/vc-feedstock/issues/94
+      downstreams:          # [win]
+        - clang_win-64      # [win]
+        - clangxx_win-64    # [win]
+        - clang-cl_win-64   # [win]
     about:
       summary: >-
         Activation and version verification of MSVC {{ vcver }}

--- a/recipe/vc_repack.py
+++ b/recipe/vc_repack.py
@@ -429,6 +429,12 @@ def main():
             ) as w:
                 for line in r:
                     w.write(subs(line, args))
+        targetdir = os.path.join(env.prefix, "etc", "conda", "deactivate.d")
+        os.makedirs(targetdir)
+        shutil.copyfile(
+            os.path.join(env.recipe_dir, "deactivate.bat"),
+            os.path.join(targetdir, f"vs{args.activate_year}_compiler_vars.bat"),
+        )
         targetdir = os.path.join(env.prefix, "etc", "conda-build", "dsolists.d")
         os.makedirs(targetdir)
         # Implement CEP-28


### PR DESCRIPTION
This was first merged in #93, then reverted in #96, reapplied a couple months later in #95 (while being more conservative with unsetting values that might still be needed), and then reverted again pretty much immediately in #99. Xref #94

Given this history here, I think it would make sense to publish these builds to a separate label first and test them on feedstocks that previously were affected. Happy to do this on a separate branch, if desired.