### PR TITLE
 remove quotes around `--pkg-config-path` in win's MESON_ARGS

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -109,7 +109,7 @@ set "MESON_ARGS=-Dbuildtype=release"
 IF "%CONDA_BUILD%" == "1" (
   :: for -DPython_FIND_REGISTRY see https://github.com/conda-forge/conda-smithy/issues/2319
   set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DPython_FIND_REGISTRY=NEVER -DPython3_FIND_REGISTRY=NEVER -DCMAKE_PROGRAM_PATH=%BUILD_PREFIX%\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\Library\bin;%PREFIX%\bin;%PREFIX%\Scripts;%PREFIX%\Library\bin"
-  set "MESON_ARGS=%MESON_ARGS% --prefix=%LIBRARY_PREFIX% --pkg-config-path=\"%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig\" -Dlibdir=lib"
+  set "MESON_ARGS=%MESON_ARGS% --prefix=%LIBRARY_PREFIX% --pkg-config-path=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig -Dlibdir=lib"
 )
 
 :: set CMAKE_* variables

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@
 
 {% set clang_test_version = "21.1.8" %}
 
-{% set build_num = 37 %}
+{% set build_num = 38 %}
 
 package:
   name: vs{{ vsyear }}


### PR DESCRIPTION
Follow-up to #123; in https://github.com/conda-forge/staged-recipes/pull/33319 I'm seeing
```
--pkg-config-path=\"%PREFIX%\Library\lib\pkgconfig;%PREFIX%\Library\share\pkgconfig\"
```
in the logs; i.e. the backslashes do not escape things as intended. ~Use the right batch-ism for that.~ Remove the quotes as they're not actually necessary