### PR TITLE
fix `CMAKE_GEN` for vs2026

### DIFF
--- a/recipe/activate.bat
+++ b/recipe/activate.bat
@@ -136,6 +136,8 @@ if "%NEWER_VS_WITH_OLDER_VC%" == "1" (
   echo "%LATEST_VS%"
   if "%LATEST_VS:~0,4%" == "14.2" (
     set "CMAKE_GEN=Visual Studio 16 2019"
+  ) else if "%LATEST_VS:~0,4%" == "14.5" (
+    set "CMAKE_GEN=Visual Studio 18 2026"
   ) else (
     set "CMAKE_GEN=Visual Studio 17 2022"
   )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@
 
 {% set clang_test_version = "21.1.8" %}
 
-{% set build_num = 38 %}
+{% set build_num = 39 %}
 
 package:
   name: vs{{ vsyear }}


### PR DESCRIPTION
closes gh-125
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
